### PR TITLE
Reformatted categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,35 +8,39 @@ Feel free to contribute and make pull requests.
 - [CSS Grid](#cssgrid)
 - Box Model
 
-<a name="general"></a>
-
-## General Styling
+<a name="basic-css"></a>
+## Basic CSS
 
 - [Getting to know CSS by Shayhowe](https://learn.shayhowe.com/html-css/getting-to-know-css/)
-- [Bits of Code](https://bitsofco.de/)
-- [CSS Diner by Luke Pacholski](https://flukeout.github.io/)
 - [Introduction to CSS by Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS)
-- [Learn CSS by Codecademy](https://www.codecademy.com/learn/learn-css)
+
+<a name="tutorials"></a>
+## Tutorials
+
+- [CSS Diner by Luke Pacholski](https://flukeout.github.io/)
 - [CSS Tutorial by Tutorials Point](https://www.tutorialspoint.com/css/index.htm)
+- [W3Schools](https://www.w3schools.com/css/)
+
+<a name="flexbox"></a>
+### Flexbox
+
+- [A Complete Guide to Flexbox by CSS Tricks](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
+
+<a name="cssgrid"></a>
+### CSS Grid
+
+- [Getting Started with CSS Grid by CSS Tricks](https://css-tricks.com/getting-started-css-grid/)
+- [A Complete Guild to Grid by CSS Tricks](https://css-tricks.com/snippets/css/complete-guide-grid/)
+- [CSS Grid by Wes Bos](https://cssgrid.io/)
+
+<a name="blogs-resources"></a>
+## Blogs and Other Resources
+
+- [Bits of Code](https://bitsofco.de/)
+- [Learn CSS by Codecademy](https://www.codecademy.com/learn/learn-css)
 - [CSS Tricks](https://css-tricks.com/)
 - [Smashing Magazine](https://www.smashingmagazine.com/category/css)
 - [Responsive Design Weekly](http://responsivedesignweekly.com/)
 - [A list Apart](https://alistapart.com/topic/css)
 - [CSS Wizardry](https://csswizardry.com/archive/)
 - [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/CSS)
-- [W3Schools](https://www.w3schools.com/css/)
-- [Quackit](https://www.quackit.com/css/)
-
-<a name="flexbox"></a>
-
-### Flexbox
-
-- [A Complete Guide to Flexbox by CSS Tricks](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
-
-<a name="cssgrid"></a>
-
-### CSS Grid
-
-- [Getting Started with CSS Grid by CSS Tricks](https://css-tricks.com/getting-started-css-grid/)
-- [A Complete Guild to Grid by CSS Tricks](https://css-tricks.com/snippets/css/complete-guide-grid/)
-- [CSS Grid by Wes Bos](https://cssgrid.io/)


### PR DESCRIPTION
This commit addresses https://github.com/hellotunmbi/css-tutorials/issues/2. Broke up "General Styling" into more specific categories for easier referencing.